### PR TITLE
Fix: restart_policy was not applied to container

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
     name: "{{ wtd_docker_collabora_name }}"
     image: "{{ wtd_docker_collabora_image }}"
     state: started
+    restart_policy: always
     ports:
       - "{{ wtd_docker_collabora_ports }}"
     env:


### PR DESCRIPTION
- restart_policy: always
- container now starts automatically after system reboot

## Reference
 - Resolves: #7