### PR TITLE
Fix: keep docker image updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ git clone https://github.com/while-true-do/ansible-role-docker-collabora.git whi
 ---
 wtd_docker_collabora_image: "collabora/code"
 
+# keep the docker image updated
+wtd_docker_collabora_image_update: true
+
 wtd_docker_collabora_name: "collabora-online"
 
 wtd_docker_collabora_ports: "127.0.0.1:9980:9980"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 wtd_docker_collabora_image: "collabora/code"
 
+# keep the docker image updated
+wtd_docker_collabora_image_update: true
+
 wtd_docker_collabora_name: "collabora-online"
 
 wtd_docker_collabora_ports: "127.0.0.1:9980:9980"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: "Get latest Docker image: {{ wtd_docker_collabora_image }}"
   docker_image:
     name: "{{ wtd_docker_collabora_image }}"
+    force: "{{ wtd_docker_collabora_image_update }}"
 
 - name: Start container
   docker_container:


### PR DESCRIPTION
# Fix: keep docker image updated

Add the force parameter to the docker_image module and make it optional.
This way the docker image gets updated if there is a new version on docker hub.

## Reference

 - Resolves: #12 